### PR TITLE
Adding link to current (1.1.x) bug repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Bug Repository for Nitrux 1.0.x Releases
+NOTE: Bugs for Nitrux `1.1.x` can be reported [here](https://github.com/Nitrux/nitrux-current-bug-tracker)
+
 ## How to report bugs
 Nitrux uses GitHub to keep track of bugs and their fixes.
 


### PR DESCRIPTION
Some [places](https://distrowatch.com/table.php?distribution=nitrux) still mention the old bug repo. 
It will be helpful if we add a link to the current one in this repo too.